### PR TITLE
Finalize results

### DIFF
--- a/examples/example_Student.py
+++ b/examples/example_Student.py
@@ -45,16 +45,12 @@ for result in prgi.results():
 print("Changing grades")
 
 try:
-    lab1 = prgi.results(component="LAB1")[0]
-    lab1.set_grade("P", "2021-02-23")
-except Exception as err:
-    print(f"Couldn't change LAB1: {err}")
-
-try:
     lab2 = prgi.results(component="LAB2")[0]
     lab2.set_grade("P", "2021-02-18")
 except Exception as err:
     print(f"Couldn't change LAB2: {err}")
+
+lab2.finalize()
 
 for result in prgi.results():
     print(f"{result.component} {result.grade} ({result.date})", end="")

--- a/examples/prgi.nw
+++ b/examples/prgi.nw
@@ -126,6 +126,7 @@ def report_results(course_code, component_name, results):
       course = student.courses(code=course_code)[0]
       result = course.results(component=component_name)[0]
       result.set_grade(result.grade, result.date)
+      result.finalize()
     except Exception as err:
       try:
         print(f"{student}: {err}")

--- a/src/ladok3/api.nw
+++ b/src/ladok3/api.nw
@@ -268,6 +268,11 @@ The output looks like this.
 \stdoutpythontex[verbatim]
 
 
+\chapter{Results-related API calls}
+
+In this chapter we look at how to fetch results from LADOK and report new 
+results to LADOK.
+
 \section{Reported results}
 
 There are two ways to get results.

--- a/src/ladok3/api.nw
+++ b/src/ladok3/api.nw
@@ -2,8 +2,9 @@
 
 We will now document some possible API calls to LADOK.
 
-To make things easier, we will add two methods, [[get_query]] and 
-[[put_query]], which are shortcuts to make GET and PUT queries to LADOK.
+To make things easier, we will add three methods: [[get_query]], [[put_query]] 
+and [[post_query]], which are shortcuts to make GET, PUT and POST queries to 
+LADOK.
 <<LadokSession data methods>>=
 def get_query(self, path, content_type="application/vnd.ladok-resultat+json"):
   """Returns GET query response for path on the LADOK server"""
@@ -25,6 +26,19 @@ def put_query(self, path, put_data,
   return self.session.put(
     url=self.base_gui_proxy_url + path,
     json=put_data,
+    headers=headers)
+
+def post_query(self, path, post_data,
+  content_type="application/vnd.ladok-resultat+json"):
+  """Returns POST query response for path on the LADOK server"""
+  headers = self.headers.copy()
+  headers["Content-Type"] = content_type
+  headers["X-XSRF-TOKEN"] = self.get_xsrf_token()
+  headers["Referer"] = self.base_gui_url
+
+  return self.session.post(
+    url=self.base_gui_proxy_url + path,
+    json=post_data,
     headers=headers)
 @
 
@@ -275,7 +289,7 @@ results to LADOK.
 
 \section{Reported results}
 
-There are two ways to get results.
+There are two ways to get results for a course.
 One method gives more data than the other.
 
 \subsection{[[search_reported_results_JSON]]}
@@ -365,22 +379,54 @@ The output looks like this.
 \stdoutpythontex[verbatim]
 
 
-\section{Creating results}
+\section{Results for a student: [[student_results_JSON]]}
 
-This section covers how to create results.
+This method pulls results for an individual student for a particular course.
+<<LadokSession data methods>>=
+def student_results_JSON(self, student_id, course_round_id):
+  """Returns the results for a student on a course round"""
+  response = self.get_query(
+    '/resultat/studieresultat/student/' + student_id +
+        '/utbildningstillfalle/' + course_round_id
+  )
 
-\subsection{[[create_result_draft_JSON]]}
+  if response.status_code == 200:
+    return response.json()
+  raise Exception(response.json()["Meddelande"])
+@
+ 
+This method is used as follows.
+\begin{pyblock}[apitest][numbers=left,firstnumber=last]
+results = ladok.student_results_JSON(me.ladok_id, dasak10.round_id)
+
+ladok3.clean_data(results)
+print(json.dumps(results, indent=2))
+\end{pyblock}
+The output looks like this.
+\stdoutpythontex[verbatim]
+
+
+\section{Modifying results}
+
+We have two alternatives: add a new result or update and existing result draft.
+
+\subsection{[[create_result_JSON]]}
 
 This method is used to create a new result.
 This result will be a draft.
 It must later be finalized and then attested.
+
+Note that since this is a new result, we must provide the [[StudieresultatUID]] 
+where we want to add the result.
+When we've done this, we'll get a [[ResultatUID]] back in the response.
+From then on, it's the [[ResultatUID]] that's interesting.
 <<LadokSession data methods>>=
 def create_result_JSON(self,
       grade_id, grade_scale_id, date,
-      study_result_id, education_id,
+      study_result_id, instance_id,
       notes=[]):
   """Creates a new result"""
-  response = self.put_query(
+  response = self.post_query(
     "/resultat/studieresultat/skapa",
     {"Resultat": [{
       "Betygsgrad": grade_id,
@@ -388,8 +434,37 @@ def create_result_JSON(self,
       "Examinationsdatum": date,
       "Noteringar": notes,
       "StudieresultatUID": study_result_id,
-      "UtbildningsinstansUID": education_id
+      "UtbildningsinstansUID": instance_id
     }]}
+  )
+
+  if response.status_code == 200:
+    return response.json()["Resultat"]
+  raise Exception(response.json()["Meddelande"])
+@
+
+\subsection{[[update_result_JSON]]}
+
+This method updates an existing result draft.
+Note that we cannot use this method to update a finalized result.
+Note also that we use the [[ResultatUID]] and not the [[StudieresultatUID]] as 
+we did for [[create_result_JSON]].
+<<LadokSession data methods>>=
+def update_result_JSON(self,
+      grade_id, grade_scale_id, date,
+      result_id, last_modified, notes=[]):
+  response = self.put_query(
+    '/resultat/studieresultat/uppdatera',
+    {
+      'Resultat': [{
+        'ResultatUID': result_id,
+        'Betygsgrad': grade_id,
+        'BetygsskalaID': grade_scale_id,
+        'Noteringar': notes,
+        'Examinationsdatum': date,
+        'SenasteResultatandring': last_modified
+      }]
+    }
   )
 
   if response.status_code == 200:
@@ -456,16 +531,45 @@ print(json.dumps(reporters[8], indent=2))
 The output looks like this.
 \stdoutpythontex[verbatim]
 
+\subsection{[[user_info_JSON]]}
+
+Usually, we want to set the reporter to the logged-in user.
+We can use the following API call to get information about the logged-in user.
+<<LadokSession data methods>>=
+def user_info_JSON(self):
+  response = self.get_query(
+    "/kataloginformation/anvandare/anvandarinformation",
+    "application/vnd.ladok-kataloginformation+json"
+  )
+
+  if response.status_code == 200:
+    return response.json()
+  raise Exception(response.text)
+@
+
+This method is used as follows.
+\begin{pyblock}[apitest][numbers=left,firstnumber=last]
+me_teacher = ladok.user_info_JSON()
+ladok3.remove_links(me_teacher)
+
+print(json.dumps(me_teacher, indent=2))
+\end{pyblock}
+The output looks like this.
+\stdoutpythontex[verbatim]
+
 \subsection{[[finalize_result_JSON]]}
 
 Finally, we can finalize the reported grade.
+If [[attestant_id]] is not [[None]], then LADOK will send a notification to 
+that person.
 <<LadokSession data methods>>=
-def finalize_result_JSON(self, result_id, last_modified, reporter_id):
+def finalize_result_JSON(self,
+    result_id, last_modified, reporter_id, attestant_id=None):
   """Marks a result as finalized (klarmarkera)"""
   response = self.put_query(
     f"/resultat/studieresultat/resultat/{result_id}/klarmarkera",
     {
-      "Beslutsfattare": [],
+      "Beslutsfattare": [attestant_id] if attestant_id else [],
       "RattadAv": [reporter_id],
       "ResultatetsSenastSparad": last_modified
     }

--- a/src/ladok3/api.nw
+++ b/src/ladok3/api.nw
@@ -202,6 +202,72 @@ The output looks like this.
 \stdoutpythontex[verbatim]
 
 
+\section{Course components}
+
+There are two ways to get the components for a course.
+
+\subsection{[[course_round_components_JSON]]}
+
+This method fetches the course components of a course round from LADOK.
+It requires the course round ID.
+This one includes data such as the number of registered students as well, 
+unlike the method in the next section.
+<<LadokSession data methods>>=
+def course_round_components_JSON(self, round_id):
+  response = self.put_query(
+    "/resultat/kurstillfalle/moment",
+    {"Identitet": [round_id]}
+  )
+
+  if response.status_code == 200:
+    return response.json()["MomentPerKurstillfallen"]
+  raise Exception(response.json()["Meddelande"])
+@
+
+This method is used as follows.
+\begin{pyblock}[apitest][numbers=left,firstnumber=last]
+try:
+  components = ladok.course_round_components_JSON(dasak10.round_id)
+except Exception as err:
+  print(f"error: {err}")
+else:
+  ladok3.clean_data(components)
+  print(json.dumps(components, indent=2))
+\end{pyblock}
+The output looks like this.
+\stdoutpythontex[verbatim]
+
+
+\subsection{[[course_instance_components_JSON]]}
+
+This method fetches the course components for a course instance, \ie a version 
+of the syllabus.
+<<LadokSession data methods>>=
+def course_instance_components_JSON(self, course_instance_id):
+  response = self.put_query(
+    "/resultat/utbildningsinstans/moduler",
+    {"Identitet": [course_instance_id]}
+  )
+
+  if response.status_code == 200:
+    return response.json()["Utbildningsinstans"][0]
+  raise Exception(response.json()["Meddelande"])
+@
+
+This method is used as follows.
+\begin{pyblock}[apitest][numbers=left,firstnumber=last]
+try:
+  components = ladok.course_instance_components_JSON(dasak10.instance_id)
+except Exception as err:
+  print(f"error: {err}")
+else:
+  ladok3.clean_data(components)
+  print(json.dumps(components, indent=2))
+\end{pyblock}
+The output looks like this.
+\stdoutpythontex[verbatim]
+
+
 \section{Reported results}
 
 There are two ways to get results.
@@ -292,6 +358,118 @@ print(json.dumps(results, indent=2))
 \end{pyblock}
 The output looks like this.
 \stdoutpythontex[verbatim]
+
+
+\section{Creating results}
+
+This section covers how to create results.
+
+\subsection{[[create_result_draft_JSON]]}
+
+This method is used to create a new result.
+This result will be a draft.
+It must later be finalized and then attested.
+<<LadokSession data methods>>=
+def create_result_JSON(self,
+      grade_id, grade_scale_id, date,
+      study_result_id, education_id,
+      notes=[]):
+  """Creates a new result"""
+  response = self.put_query(
+    "/resultat/studieresultat/skapa",
+    {"Resultat": [{
+      "Betygsgrad": grade_id,
+      "BetygsskalaID": grade_scale_id,
+      "Examinationsdatum": date,
+      "Noteringar": notes,
+      "StudieresultatUID": study_result_id,
+      "UtbildningsinstansUID": education_id
+    }]}
+  )
+
+  if response.status_code == 200:
+    return response.json()["Resultat"]
+  raise Exception(response.json()["Meddelande"])
+@
+
+\section{Finalizing a result}
+
+Here we cover the API calls needed to finalize (klarmarkera) a result in LADOK.
+
+\subsection{[[result_attestants_JSON]] and [[result_reporters_JSON]]}
+
+To finalize a result, we must know two things: who is reporting and who can 
+attest.
+We start with who can attest.
+<<LadokSession data methods>>=
+def result_attestants_JSON(self, result_id):
+  """Returns a list of result attestants"""
+  response = self.put_query(
+    "/resultat/anvandare/resultatrattighet/attestanter/kurstillfallesrapportering",
+    {"Identitet": [result_id]}
+  )
+
+  if response.status_code == 200:
+    return response.json()["Anvandare"]
+  raise Exception(response.json()["Meddelande"])
+@ The [[result_id]] is the ID returned in the [[ResultatUID]] field in the 
+response from the [[create_result_JSON]] method.
+
+This method is used as follows.
+\begin{pyblock}[apitest][numbers=left,firstnumber=last]
+attestants = ladok.result_attestants_JSON(
+  "a1ff1fda-881e-11eb-b9f5-10126f8746d1")
+
+print(json.dumps(attestants[0], indent=2))
+\end{pyblock}
+The output looks like this.
+\stdoutpythontex[verbatim]
+
+Now, we get a list of who can report (basically anyone registered in the entire 
+organization).
+<<LadokSession data methods>>=
+def result_reporters_JSON(self, organization_id):
+  """Returns a list of who can report results in an organization"""
+  response = self.get_query(
+    "/kataloginformation/anvandare/organisation/" +
+      organization_id + "/resultatrapportorer",
+    "application/vnd.ladok-kataloginformation+json"
+  )
+
+  if response.status_code == 200:
+    return response.json()["Anvandare"]
+  raise Exception(response.text)
+@
+
+This method is used as follows.
+\begin{pyblock}[apitest][numbers=left,firstnumber=last]
+reporters = ladok.result_reporters_JSON(components["OrganisationUID"])
+ladok3.remove_links(reporters)
+
+print(json.dumps(reporters[8], indent=2))
+\end{pyblock}
+The output looks like this.
+\stdoutpythontex[verbatim]
+
+\subsection{[[finalize_result_JSON]]}
+
+Finally, we can finalize the reported grade.
+<<LadokSession data methods>>=
+def finalize_result_JSON(self, result_id, last_modified, reporter_id):
+  """Marks a result as finalized (klarmarkera)"""
+  response = self.put_query(
+    f"/resultat/studieresultat/resultat/{result_id}/klarmarkera",
+    {
+      "Beslutsfattare": [],
+      "RattadAv": [reporter_id],
+      "ResultatetsSenastSparad": last_modified
+    }
+  )
+
+  if response.status_code == 200:
+    return response.json()
+  raise Exception(response.json()["Meddelande"])
+@ This method returns a copy of the finalized result.
 
 
 \section{[[participants_JSON]]}

--- a/src/ladok3/ladok3.nw
+++ b/src/ladok3/ladok3.nw
@@ -713,7 +713,7 @@ the same way.
 \inputminted[firstline=19,lastline=29]{python}{../examples/example_Student.py}
 We can check if the result is attested or not.
 If it's not attested, we can change it.
-\inputminted[firstline=32,lastline=51]{python}{../examples/example_Student.py}
+\inputminted[firstline=32,lastline=53]{python}{../examples/example_Student.py}
 
 
 \section{Getting students from LADOK}
@@ -1535,12 +1535,10 @@ We construct [[CourseResult]] objects using a [[CourseRegistration]] object.
 From the response we get from LADOK, we construct [[CourseResult]] objects that 
 deal with the details.
 <<pull existing CourseResult objects from LADOK>>=
-response = self.ladok.session.get(
-  url=self.ladok.base_gui_proxy_url +
-    '/resultat/studieresultat/student/' + self.__student.ladok_id +
-      '/utbildningstillfalle/' + self.round_id,
-  headers=self.ladok.headers).json()
-    
+response = self.ladok.student_results_JSON(
+  self.__student.ladok_id, self.round_id
+)
+
 self.__results_id = response["Uid"]
 self.__results = []
 for result in response["ResultatPaUtbildningar"]:
@@ -1585,17 +1583,16 @@ class CourseResult(LadokRemoteData):
     super().__init__(**kwargs)
 
     self.__student = kwargs.pop("student")
+    self.__study_results_id = kwargs.pop("study_results_id")
 
-    if "component" in kwargs and "study_results_id" in kwargs:
+    if "component" in kwargs:
       self.__component = kwargs.pop("component")
-      self.__study_results_id = kwargs.pop("study_results_id")
       self.__populate_attributes()
     elif "components" in kwargs and \
         ("Arbetsunderlag" in kwargs or "SenastAttesteradeResultat" in kwargs):
       components = kwargs.pop("components")
       if "Arbetsunderlag" in kwargs:
         data = kwargs.pop("Arbetsunderlag")
-        self.__last_modified = data.pop("SenasteResultatandring")
       elif "SenastAttesteradeResultat" in kwargs:
         data = kwargs.pop("SenastAttesteradeResultat")
       self.__populate_attributes(**data, components=components)
@@ -1633,6 +1630,13 @@ class CourseResult(LadokRemoteData):
     self.__modified = True
     self.push()
 
+  def finalize(self, notify=False):
+    """Finalizes the set grade"""
+    if self.modified:
+      self.push()
+
+    <<finalize the grade for CourseResult>>
+
   @property
   def modified(self):
     """Returns True if there are unpushed changes"""
@@ -1658,12 +1662,15 @@ class CourseResult(LadokRemoteData):
       <<push the existing CourseResult grade data to LADOK>>
     else:
       <<push the new CourseResult grade data to LADOK>>
+    self.__modified = False
 @
 
 If we get the data from LADOK, then we can fill in all the attributes.
 <<populate CourseResult attributes from data>>=
 self.__uid = data.pop("Uid")
 self.__instance_id = data.pop("UtbildningsinstansUID")
+self.__results_id = data.pop("ResultatUID")
+self.__study_results_id = data.pop("StudieresultatUID")
 
 grade_scale_id = data.pop("BetygsskalaID")
 grade = data.pop("Betygsgrad")
@@ -1728,31 +1735,18 @@ self.__date = date
 
 To push an updated result to LADOK, we do the following.
 <<push the existing CourseResult grade data to LADOK>>=
-headers = self.ladok.headers.copy()
-headers['Content-Type'] = 'application/vnd.ladok-resultat+json'
-headers['X-XSRF-TOKEN'] = self.ladok.xsrf_token
-headers['Referer'] = self.ladok.base_gui_url
-
-put_data = {
-  'Resultat': [{
-    'ResultatUID': self.__uid,
-    'Betygsgrad': self.grade.id,
-    'Noteringar': [],
-    'BetygsskalaID': self.grade_scale.id,
-    'Examinationsdatum': self.date.isoformat(),
-    'SenasteResultatandring': self.__last_modified
-  }]
-}
-response = self.ladok.session.put(
-  url=self.ladok.base_gui_proxy_url + '/resultat/studieresultat/uppdatera',
-  json=put_data,
-  headers=headers)
-
-if 'Resultat' not in response.json():
+try:
+  response = self.ladok.update_result_JSON(
+    self.grade.id, self.grade_scale.id, self.date.isoformat(),
+    self.__uid, self.__last_modified
+  )
+except Exception as err:
   raise Exception(
     f"couldn't update {self.component.code} to {self.grade} ({self.date})"
-    f" to LADOK: {response.json()['Meddelande']}"
+    f" to LADOK: {err}"
   )
+
+self.__populate_attributes(**response[0])
 @
 
 \subsection{Adding new results}
@@ -1762,32 +1756,33 @@ Since we don't update an already existing item, we must add a new result to
 LADOK.
 Particularly, we must add something to the student's study results.
 <<push the new CourseResult grade data to LADOK>>=
-headers = self.ladok.headers.copy()
-headers['Content-Type'] = 'application/vnd.ladok-resultat+json'
-headers['X-XSRF-TOKEN'] = self.ladok.get_xsrf_token()
-headers['Referer'] = self.ladok.base_gui_url
-
-post_data = {
-  'Resultat': [{
-    'StudieresultatUID': self.__study_results_id,
-    'UtbildningsinstansUID': self.__instance_id,
-    'Betygsgrad': self.grade.id,
-    'Noteringar': [],
-    'BetygsskalaID': self.grade_scale.id,
-    'Examinationsdatum': self.date.isoformat()
-  }]
-}
-
-response = self.ladok.session.post(
-  url=self.ladok.base_gui_proxy_url + '/resultat/studieresultat/skapa',
-  json=post_data,
-  headers=headers)
-
-if not 'Resultat' in response.json():
+try:
+  response = self.ladok.create_result_JSON(
+    self.grade.id, self.grade_scale.id, self.date.isoformat(),
+    self.__study_results_id, self.__instance_id
+  )
+except Exception as err:
   raise Exception("Couldn't register "
-    f"{self.component} {self.grade} {self.date}: " +
-      response.json()["Meddelande"])
+    f"{self.component} {self.grade} {self.date}: {err}")
 
-self.__populate_attributes(**response.json()["Resultat"][0])
+self.__populate_attributes(**response[0])
 @
 
+
+\subsection{Finalizing a result}
+
+When we finalize the result, we must know who reported the result.
+<<finalize the grade for CourseResult>>=
+reporter_id = self.ladok.user_info_JSON()["AnvandareUID"]
+
+if notify:
+  response = self.ladok.finalize_result_JSON(
+    self.__results_id, self.__last_modified, reporter_id, reporter_id
+  )
+else:
+  response = self.ladok.finalize_result_JSON(
+    self.__results_id, self.__last_modified, reporter_id
+  )
+
+self.__populate_attributes(**response)
+@

--- a/src/ladok3/report.nw
+++ b/src/ladok3/report.nw
@@ -40,6 +40,8 @@ try:
   course = student.courses(code=args.course_code)[0]
   result = course.results(component=args.component_code)[0]
   result.set_grade(args.grade, args.date)
+  if args.finalize:
+    result.finalize()
 except Exception as err:
   try:
     print(f"{student}: {err}")
@@ -66,7 +68,7 @@ report_parser.add_argument("grade",
 )
 @
 
-Finally, we have the date.
+Next, we have the date.
 To ensure it's a valid date we'll make [[argparse]] convert it to [[datetime]] 
 format.
 If it's not provided, we let [[argparse]] set it to today's date.
@@ -76,6 +78,16 @@ report_parser.add_argument("-d", "--date",
     f"defaults to today's date ({datetime.date.today()})",
   type=datetime.date.fromisoformat,
   default=datetime.date.today()
+)
+@
+
+Finally, we add an option whether we want to finalize the grade for attestation 
+by the examiner.
+<<add report command arguments to report parser>>=
+report_parser.add_argument("-f", "--finalize",
+  help="Finalize the grade (mark as ready/klarmarkera) for examiner to attest",
+  action="store_true",
+  default=False
 )
 @
 


### PR DESCRIPTION
This allows us to finalize results (fixes #13).
- [x] Add API calls for finalizing grades.
- [x] Add finalizing calls to the framework, e.g. a `finalize` method for results.