### PR TITLE
Fixed an error message where an intended f-string contained the f

### DIFF
--- a/src/ladok3/report.nw
+++ b/src/ladok3/report.nw
@@ -163,7 +163,7 @@ error message.
 try:
   course = student.courses(code=args.course_code)[0]
 except IndexError:
-  raise Exception("f{args.course_code}: No such course for {student}")
+  raise Exception(f"{args.course_code}: No such course for {student}")
 <<look up [[result]] from [[course]]>>=
 try:
   result = course.results(component=args.component_code)[0]


### PR DESCRIPTION
The error message below contained an f intended to signal to Python that it was an f-string. I fixed it.
$ ladok report -f DD1366 MAS1 [STUDENT_ID_REDACTED] P 2025-01-08 'Marcus Dicander <dicander@kth.se>'
Expecting value: line 1 column 1 (char 0): [STUDENT_ID_REDACTED]: f{args.course_code}: No such course for {student}
$